### PR TITLE
Use objectify

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # SymWalker
 
-[![Go Reference](https://pkg.go.dev/badge/github.com/orme292/symwalker@v0.1.72.svg)](https://pkg.go.dev/github.com/orme292/symwalker@v0.1.72)
+[![Go Reference](https://pkg.go.dev/badge/github.com/orme292/symwalker@v0.1.8.svg)](https://pkg.go.dev/github.com/orme292/symwalker@v0.1.8)
 
 SymWalker is a directory tree walker with symlink loop protection. It works by building a
 separate history for each sub-directory branch (internally called lineHistory) underneath
@@ -11,7 +11,7 @@ other directory entries.
 ## Import this Module
 
 ```shell
-go get github.com/orme292/symwalker@v0.1.72
+go get github.com/orme292/symwalker@v0.1.8
 ```
 
 ```go
@@ -22,15 +22,14 @@ import (
 
 ## Usage
 
-Symwalker uses a functional options pattern to create a configuration object.
+SymWalker uses a functional options pattern to apply an optional configuration.
 
-### Build Configuration
+### Build Optional Configuration
 
 ```go
 func main() {
 
-    conf := sw.NewSymConf(
-        sw.WithStartPath("/home/andrew/"),
+opts := sw.NewSymConf("/home/andrew/",
         sw.WithFollowedSymLinks(),
         sw.WithLogging(), 
     )
@@ -40,8 +39,10 @@ func main() {
 
 ### Options
 
-`WithStartPath("path")`: required in order to specify the path to be walked. This has to be
-a path to a directory, not a file or a symlink.
+`WithDepth(n)`: Used to tell SymWalker how deep to walk from the starting path. `0` is infinite while `1` would walk
+only the provided starting path.
+
+`WithFileData()`: SymWalker will populate the FileObj field in each DirEntry with file information.
 
 `WithFollowedSymLinks()`: Used to tell SymWalker that it SHOULD evaluate and/or walk symlinks.
 
@@ -51,11 +52,11 @@ a path to a directory, not a file or a symlink.
 
 ### Call SymWalk
 
-The `SymWalk` function is the starting point for SymWalker. Call the function and pass a SymConf
-configuration object to it to begin the directory walk.
+The `SymWalk` function is the starting point for SymWalker. Call the function by passing the starting path and an
+options configuration object to begin the directory walk.
 
 ```go
-results, err := sw.SymWalker(conf)
+results, err := sw.SymWalker("root_path", opts)
 ```
 
 ### The *Results* Type Struct
@@ -78,7 +79,8 @@ type DirEntries []DirEntry
 
 ```go
 type DirEntry struct {
-    Path string
+Path    string
+FileObj objectify.FileObj
 }
 ```
 
@@ -93,6 +95,11 @@ Each `Results.Others` DirEntry could have a `Path` value set to a directory entr
 See documentation for the [os.FileMode](https://pkg.go.dev/os#FileMode) type. `Results.Dirs` are paths which
 match `ModeDir` (os.FileMode *or* fs.FileMode). `Results.Others` files are paths which match any type other
 than `ModeDir`. `Results.Files` are paths which match no `os.FileMode` type.
+
+## `FileObj` Field
+
+For the `FileObj` field, see the [Objectify](https://github.com/orme292/objectify) library
+[documentation](https://pkg.go.dev/github.com/orme292/objectify@v0.1.0) for information.
 
 ## Example
 
@@ -111,8 +118,7 @@ import (
 
 func main() {
 
-    conf := sw.NewSymConf(
-        sw.WithStartPath("/home/andrew/"),
+    conf := sw.NewSymConf("/home/andrew/",
         sw.WithFollowedSymLinks(),
         sw.WithLogging(),
     )

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,8 @@
 module github.com/orme292/symwalker
 
 go 1.22.0
+
+require (
+	github.com/kardianos/osext v0.0.0-20190222173326-2bc1f35cddc0 // indirect
+	github.com/orme292/objectify v0.2.0 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,4 @@
+github.com/kardianos/osext v0.0.0-20190222173326-2bc1f35cddc0 h1:iQTw/8FWTuc7uiaSepXwyf3o52HaUYcV+Tu66S3F5GA=
+github.com/kardianos/osext v0.0.0-20190222173326-2bc1f35cddc0/go.mod h1:1NbS8ALrpOvjt0rHPNLyCIeMtbizbir8U//inJ+zuB8=
+github.com/orme292/objectify v0.2.0 h1:MvvhrDh8q/AOI4RA58V3rsUs7/2Je6hvQDT1jg8TiM0=
+github.com/orme292/objectify v0.2.0/go.mod h1:3+eIByxdnnMDiJ2cjByPvAttulndjAjzITugTdEo1X4=

--- a/type_direntry.go
+++ b/type_direntry.go
@@ -1,9 +1,14 @@
 package symwalker
 
+import (
+	objf "github.com/orme292/objectify"
+)
+
 // DirEntry holds directory entry information.
 // marked is a flag used to indicate whether the DirEntry
 // has been processed/walked.
 type DirEntry struct {
-	Path   string
-	marked bool
+	Path    string
+	FileObj *objf.FileObj
+	marked  bool
 }

--- a/type_results.go
+++ b/type_results.go
@@ -1,13 +1,31 @@
 package symwalker
 
+import (
+	objf "github.com/orme292/objectify"
+)
+
 // DirEntries holds each directory entry.
 type DirEntries []DirEntry
 
-// add adds a new directory entry to the DirEntries
-// slice if the path does not already exist.
-func (re *DirEntries) add(p string) {
-	if !re.pathExists(p) {
-		*re = append(*re, DirEntry{Path: p})
+// add appends a new DirEntry to the DirEntries slice.
+// path is checked to see if it exists before adding. If it does, no
+// new element is appended.
+// If withData flag is true, then the FileObj field is populated
+// with file data from objectify, and the path field, then appended.
+// If withData is false, then the Path field is populated and appended.
+func (re *DirEntries) add(path string, withData bool) {
+	var de DirEntry
+	if !re.pathExists(path) {
+		if withData {
+			fo, err := objf.File(path, objf.SetsAll())
+			if err != nil {
+				fo = &objf.FileObj{}
+			}
+			de = DirEntry{Path: path, FileObj: fo}
+		} else {
+			de = DirEntry{Path: path}
+		}
+		*re = append(*re, de)
 	}
 }
 

--- a/type_symconf.go
+++ b/type_symconf.go
@@ -6,13 +6,17 @@ package symwalker
 // options below can be used.
 type SymConf struct {
 	StartPath      string
-	FollowSymlinks bool
-	WithoutFiles   bool
-	Noisy          bool
 	Depth          int
-	dirs           DirEntries
-	files          DirEntries
-	others         DirEntries
+	FileData       bool
+	FollowSymlinks bool
+
+	Noisy bool
+
+	WithoutFiles bool
+
+	dirs   DirEntries
+	files  DirEntries
+	others DirEntries
 }
 
 const (
@@ -29,9 +33,13 @@ const (
 		WithLogging(),
 	)
 */
-func NewSymConf(options ...OptFunc) *SymConf {
+func NewSymConf(path string, options ...OptFunc) *SymConf {
 
-	c := &SymConf{}
+	path = fullPathSafe(path)
+
+	c := &SymConf{
+		StartPath: path,
+	}
 	for _, option := range options {
 		option(c)
 	}
@@ -41,12 +49,19 @@ func NewSymConf(options ...OptFunc) *SymConf {
 
 type OptFunc func(*SymConf)
 
-// WithStartPath accepts the path in which the directory walk
-// will start. It MUST be a directory, not a file, or a symlink to
-// a directory.
-func WithStartPath(startPath string) OptFunc {
+// WithDepth limits how many levels SymWalker will walk below
+// the provided StartPath directory. Value n can be set to
+// any number. INFINITE is equal to 0 or infinite depth. FLAT
+// is equal to 1 -- SymWalker will not go below the top level.
+func WithDepth(n int) OptFunc {
 	return func(c *SymConf) {
-		c.StartPath = startPath
+		c.Depth = n
+	}
+}
+
+func WithFileData() OptFunc {
+	return func(c *SymConf) {
+		c.FileData = true
 	}
 }
 
@@ -71,15 +86,5 @@ func WithLogging() OptFunc {
 func WithoutFiles() OptFunc {
 	return func(c *SymConf) {
 		c.WithoutFiles = true
-	}
-}
-
-// WithDepth limits how many levels SymWalker will walk below
-// the provided StartPath directory. Value n can be set to
-// any number. INFINITE is equal to 0 or infinite depth. FLAT
-// is equal to 1 -- SymWalker will not go below the top level.
-func WithDepth(n int) OptFunc {
-	return func(c *SymConf) {
-		c.Depth = n
 	}
 }

--- a/walker.go
+++ b/walker.go
@@ -40,7 +40,7 @@ func startWalkLoop(conf *SymConf) (err error) {
 
 	ent := isEntType(conf.StartPath)
 
-	readable, err := isReadable(fullPathUnsafe(conf.StartPath), ent)
+	readable, err := isReadable(fullPathSafe(conf.StartPath), ent)
 	if err != nil || !readable {
 		noise(conf.Noisy, "not readable: %s", conf.StartPath)
 		return fmt.Errorf("StartPath is not readable: %s", conf.StartPath)
@@ -62,6 +62,7 @@ func startWalkLoop(conf *SymConf) (err error) {
 	}
 
 	return nil
+
 }
 
 // dirWalk IS the primary loop. It accepts a pointer to the configuration object,
@@ -83,7 +84,7 @@ func dirWalk(conf *SymConf, basePath string, history lineHistory) (err error) {
 
 	basePathEnt := isEntType(basePath)
 
-	readable, err := isReadable(fullPathUnsafe(basePath), basePathEnt)
+	readable, err := isReadable(fullPathSafe(basePath), basePathEnt)
 	if err != nil || !readable {
 		err = fmt.Errorf("not readable: %s", basePath)
 		return
@@ -104,7 +105,7 @@ func dirWalk(conf *SymConf, basePath string, history lineHistory) (err error) {
 		}
 		history = history.add(basePath)
 
-		conf.dirs.add(basePath)
+		conf.dirs.add(basePath, conf.FileData)
 
 		entries, err := os.ReadDir(basePath)
 		if err != nil {
@@ -142,7 +143,7 @@ func dirWalk(conf *SymConf, basePath string, history lineHistory) (err error) {
 			}
 			history = history.add(target)
 
-			conf.dirs.add(basePath)
+			conf.dirs.add(basePath, conf.FileData)
 
 			entries, err := os.ReadDir(target)
 			if err != nil {
@@ -166,7 +167,7 @@ func dirWalk(conf *SymConf, basePath string, history lineHistory) (err error) {
 				break
 			}
 
-			conf.files.add(basePath)
+			conf.files.add(basePath, conf.FileData)
 
 		case entTypeOther, entTypeErrored:
 
@@ -174,7 +175,7 @@ func dirWalk(conf *SymConf, basePath string, history lineHistory) (err error) {
 				break
 			}
 
-			conf.others.add(basePath)
+			conf.others.add(basePath, conf.FileData)
 
 		}
 
@@ -184,7 +185,7 @@ func dirWalk(conf *SymConf, basePath string, history lineHistory) (err error) {
 			break
 		}
 
-		conf.files.add(basePath)
+		conf.files.add(basePath, conf.FileData)
 
 	case entTypeOther, entTypeErrored:
 
@@ -192,7 +193,7 @@ func dirWalk(conf *SymConf, basePath string, history lineHistory) (err error) {
 			break
 		}
 
-		conf.others.add(basePath)
+		conf.others.add(basePath, conf.FileData)
 
 	}
 
@@ -212,7 +213,7 @@ func processDirEntry(conf *SymConf, path string, history lineHistory) {
 
 	ent := isEntType(path)
 
-	readable, err := isReadable(fullPathUnsafe(path), ent)
+	readable, err := isReadable(fullPathSafe(path), ent)
 	if err != nil || !readable {
 		noise(conf.Noisy, "Not readable: %s", path)
 		return
@@ -266,7 +267,7 @@ func processDirEntry(conf *SymConf, path string, history lineHistory) {
 
 			noise(conf.Noisy, "Process (%s): %s", isEntType(path).string(), path)
 
-			conf.files.add(path)
+			conf.files.add(path, conf.FileData)
 
 		case entTypeOther, entTypeErrored:
 
@@ -276,7 +277,7 @@ func processDirEntry(conf *SymConf, path string, history lineHistory) {
 
 			noise(conf.Noisy, "Process (%s): %s", isEntType(path).string(), path)
 
-			conf.others.add(path)
+			conf.others.add(path, conf.FileData)
 		}
 
 	case entTypeFile:
@@ -287,7 +288,7 @@ func processDirEntry(conf *SymConf, path string, history lineHistory) {
 
 		noise(conf.Noisy, "Process (%s): %s", isEntType(path).string(), path)
 
-		conf.files.add(path)
+		conf.files.add(path, conf.FileData)
 
 	case entTypeOther, entTypeErrored:
 
@@ -297,7 +298,7 @@ func processDirEntry(conf *SymConf, path string, history lineHistory) {
 
 		noise(conf.Noisy, "Process (%s): %s", isEntType(path).string(), path)
 
-		conf.others.add(path)
+		conf.others.add(path, conf.FileData)
 
 	}
 


### PR DESCRIPTION
Add option to populate file data in each DirEntry with objectify, WithFileData() is added. SymWalker requires a starting path as the first argument, WithStartPath() is removed.